### PR TITLE
fix: panic for some map and pointers

### DIFF
--- a/binding/reflection/decode.go
+++ b/binding/reflection/decode.go
@@ -87,7 +87,7 @@ func decoderOf(extension spi.Extension, prefix string, valType reflect.Type) int
 		for i := 0; i < valType.NumField(); i++ {
 			refField := valType.Field(i)
 			fieldId := parseFieldId(refField)
-			if fieldId == 0 {
+			if fieldId == -1 {
 				continue
 			}
 			decoderField := structDecoderField{
@@ -116,19 +116,19 @@ func isEnumType(valType reflect.Type) bool {
 
 func parseFieldId(refField reflect.StructField) protocol.FieldId {
 	if !unicode.IsUpper(rune(refField.Name[0])) {
-		return 0
+		return -1
 	}
 	thriftTag := refField.Tag.Get("thrift")
 	if thriftTag == "" {
-		return 0
+		return -1
 	}
 	parts := strings.Split(thriftTag, ",")
 	if len(parts) < 2 {
-		return 0
+		return -1
 	}
 	fieldId, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return 0
+		return -1
 	}
 	return protocol.FieldId(fieldId)
 }

--- a/binding/reflection/decode_pointer.go
+++ b/binding/reflection/decode_pointer.go
@@ -15,5 +15,5 @@ func (decoder *pointerDecoder) decode(ptr unsafe.Pointer, iter spi.Iterator) {
 	value := reflect.New(decoder.valType).Interface()
 	newPtr := (*emptyInterface)(unsafe.Pointer(&value)).word
 	decoder.valDecoder.decode(newPtr, iter)
-	*((*uintptr)(ptr)) = uintptr(newPtr)
+	*(*unsafe.Pointer)(ptr) = newPtr
 }

--- a/binding/reflection/encode_pointer.go
+++ b/binding/reflection/encode_pointer.go
@@ -1,17 +1,23 @@
 package reflection
 
 import (
-	"unsafe"
-	"github.com/thrift-iterator/go/spi"
 	"github.com/thrift-iterator/go/protocol"
+	"github.com/thrift-iterator/go/spi"
+	"reflect"
+	"unsafe"
 )
 
 type pointerEncoder struct {
+	valType    reflect.Type
 	valEncoder internalEncoder
 }
 
 func (encoder *pointerEncoder) encode(ptr unsafe.Pointer, stream spi.Stream) {
-	encoder.valEncoder.encode(*((*unsafe.Pointer)(ptr)), stream)
+	valPtr := *(*unsafe.Pointer)(ptr)
+	if encoder.valType.Kind() == reflect.Map {
+		valPtr = *(*unsafe.Pointer)(valPtr)
+	}
+	encoder.valEncoder.encode(valPtr, stream)
 }
 
 func (encoder *pointerEncoder) thriftType() protocol.TType {

--- a/protocol/compact/iterator.go
+++ b/protocol/compact/iterator.go
@@ -99,14 +99,15 @@ func (iter *Iterator) ReadStructField() (protocol.TType, protocol.FieldId) {
 		fieldId = iter.lastFieldId + protocol.FieldId(modifier)
 	}
 	var fieldType protocol.TType
-	if TCompactType(firstByte&0x0f) == TypeBooleanTrue {
+	switch tType := TCompactType(firstByte & 0x0f); tType {
+	case TypeBooleanTrue:
 		fieldType = protocol.TypeBool
 		iter.pendingBoolField = 1
-	} else if TCompactType(firstByte&0x0f) == TypeBooleanFalse {
+	case TypeBooleanFalse:
 		fieldType = protocol.TypeBool
 		iter.pendingBoolField = 2
-	} else {
-		fieldType = TCompactType(firstByte & 0x0f).ToTType()
+	default:
+		fieldType = tType.ToTType()
 		iter.pendingBoolField = 0
 	}
 

--- a/protocol/compact/stream.go
+++ b/protocol/compact/stream.go
@@ -147,6 +147,7 @@ func (stream *Stream) WriteBool(val bool) {
 		stream.WriteInt16(int16(fieldId))
 	}
 	stream.lastFieldId = fieldId
+	stream.pendingBoolField = 0
 }
 
 func (stream *Stream) WriteInt8(val int8) {

--- a/protocol/sbinary/iterator.go
+++ b/protocol/sbinary/iterator.go
@@ -204,7 +204,9 @@ func (iter *Iterator) ReadString() string {
 
 func (iter *Iterator) ReadBinary() []byte {
 	size := iter.ReadUint32()
-	return iter.readLarge(int(size))
+	tmp := make([]byte, size)
+	copy(tmp, iter.readLarge(int(size)))
+	return tmp
 }
 
 func getTypeSize(elemType protocol.TType) int {

--- a/test/level_0/bool_test.go
+++ b/test/level_0/bool_test.go
@@ -1,9 +1,9 @@
 package test
 
 import (
-	"testing"
 	"github.com/stretchr/testify/require"
 	"github.com/thrift-iterator/go/test"
+	"testing"
 )
 
 func Test_decode_bool(t *testing.T) {
@@ -13,6 +13,11 @@ func Test_decode_bool(t *testing.T) {
 		proto.WriteBool(true)
 		iter := c.CreateIterator(buf.Bytes())
 		should.Equal(true, iter.ReadBool())
+
+		buf, proto = c.CreateProtocol()
+		proto.WriteBool(false)
+		iter = c.CreateIterator(buf.Bytes())
+		should.Equal(false, iter.ReadBool())
 	}
 }
 
@@ -20,10 +25,16 @@ func Test_unmarshal_bool(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.UnmarshalCombinations {
 		buf, proto := c.CreateProtocol()
+		var val1 bool
 		proto.WriteBool(true)
-		var val bool
-		should.NoError(c.Unmarshal(buf.Bytes(), &val))
-		should.Equal(true, val)
+		should.NoError(c.Unmarshal(buf.Bytes(), &val1))
+		should.Equal(true, val1)
+
+		buf, proto = c.CreateProtocol()
+		var val2 bool = true
+		proto.WriteBool(false)
+		should.NoError(c.Unmarshal(buf.Bytes(), &val2))
+		should.Equal(false, val2)
 	}
 }
 
@@ -34,6 +45,11 @@ func Test_encode_bool(t *testing.T) {
 		stream.WriteBool(true)
 		iter := c.CreateIterator(stream.Buffer())
 		should.Equal(true, iter.ReadBool())
+
+		stream = c.CreateStream()
+		stream.WriteBool(false)
+		iter = c.CreateIterator(stream.Buffer())
+		should.Equal(false, iter.ReadBool())
 	}
 }
 
@@ -44,5 +60,10 @@ func Test_marshal_bool(t *testing.T) {
 		should.NoError(err)
 		iter := c.CreateIterator(output)
 		should.Equal(true, iter.ReadBool())
+
+		output, err = c.Marshal(false)
+		should.NoError(err)
+		iter = c.CreateIterator(output)
+		should.Equal(false, iter.ReadBool())
 	}
 }

--- a/test/level_1/map_test.go
+++ b/test/level_1/map_test.go
@@ -148,14 +148,20 @@ func Test_unmarshal_map(t *testing.T) {
 func Test_marshal_general_map(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.Map{
+		m := general.Map{
 			int32(1): int64(1),
 			int32(2): int64(2),
 			int32(3): int64(3),
-		})
+		}
+
+		output, err := c.Marshal(m)
 		should.NoError(err)
-		var val general.Map
+		output1, err := c.Marshal(&m)
+		should.NoError(err)
+		var val, val1 general.Map
 		should.NoError(c.Unmarshal(output, &val))
+		should.NoError(c.Unmarshal(output1, &val1))
+		should.Equal(val, val1)
 		should.Equal(general.Map{
 			int32(1): int64(1),
 			int32(2): int64(2),
@@ -179,10 +185,15 @@ func Test_marshal_raw_map(t *testing.T) {
 		proto.WriteMapEnd()
 		var val raw.Map
 		should.NoError(c.Unmarshal(buf.Bytes(), &val))
+
 		output, err := c.Marshal(val)
 		should.NoError(err)
-		var generalVal general.Map
+		output1, err := c.Marshal(&val)
+		should.NoError(err)
+		var generalVal, generalVal1 general.Map
 		should.NoError(c.Unmarshal(output, &generalVal))
+		should.NoError(c.Unmarshal(output1, &generalVal1))
+		should.Equal(generalVal, generalVal1)
 		should.Equal(general.Map{
 			int32(1): int64(1),
 			int32(2): int64(2),
@@ -194,14 +205,20 @@ func Test_marshal_raw_map(t *testing.T) {
 func Test_marshal_map(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal(map[string]int64{
+		m := map[string]int64{
 			"k1": int64(1),
 			"k2": int64(2),
 			"k3": int64(3),
-		})
+		}
+
+		output, err := c.Marshal(m)
 		should.NoError(err)
-		var val general.Map
+		output1, err := c.Marshal(&m)
+		should.NoError(err)
+		var val, val1 general.Map
 		should.NoError(c.Unmarshal(output, &val))
+		should.NoError(c.Unmarshal(output1, &val1))
+		should.Equal(val, val1)
 		should.Equal(general.Map{
 			"k1": int64(1),
 			"k2": int64(2),

--- a/test/level_2/list_of_list_test.go
+++ b/test/level_2/list_of_list_test.go
@@ -84,15 +84,20 @@ func Test_unmarshal_list_of_list(t *testing.T) {
 func Test_marshal_general_list_of_list(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.List{
+		lst := general.List{
 			general.List{
 				int64(1),
 			},
 			general.List {
 				int64(2),
 			},
-		})
+		}
+
+		output, err := c.Marshal(lst)
 		should.NoError(err)
+		output1, err := c.Marshal(&lst)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.List
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.List{int64(1)}, val[0])
@@ -102,15 +107,20 @@ func Test_marshal_general_list_of_list(t *testing.T) {
 func Test_marshal_list_of_general_list(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal([]general.List{
+		lst := []general.List{
 			{
 				int64(1),
 			},
 			{
 				int64(2),
 			},
-		})
+		}
+
+		output, err := c.Marshal(lst)
 		should.NoError(err)
+		output1, err := c.Marshal(&lst)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.List
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.List{int64(1)}, val[0])
@@ -120,10 +130,15 @@ func Test_marshal_list_of_general_list(t *testing.T) {
 func Test_marshal_list_of_list(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal([][]int64{
+		lst := [][]int64{
 			{1}, {2},
-		})
+		}
+
+		output, err := c.Marshal(lst)
 		should.NoError(err)
+		output1, err := c.Marshal(&lst)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.List
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.List{int64(1)}, val[0])

--- a/test/level_2/list_of_map_test.go
+++ b/test/level_2/list_of_map_test.go
@@ -75,15 +75,20 @@ func Test_unmarshal_list_of_map(t *testing.T) {
 func Test_marshal_general_list_of_map(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.List{
+		lst := general.List{
 			general.Map{
 				int32(1): int64(1),
 			},
 			general.Map{
 				int32(2): int64(2),
 			},
-		})
+		}
+
+		output, err := c.Marshal(lst)
 		should.NoError(err)
+		output1, err := c.Marshal(&lst)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val []map[int32]int64
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal([]map[int32]int64{
@@ -95,9 +100,14 @@ func Test_marshal_general_list_of_map(t *testing.T) {
 func Test_marshal_list_of_map(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal([]map[int32]int64{
+		lst := []map[int32]int64{
 			{1: 1}, {2: 2},
-		})
+		}
+
+		output, err := c.Marshal(lst)
+		should.NoError(err)
+		output1, err := c.Marshal(&lst)
+		should.Equal(output, output1)
 		should.NoError(err)
 		var val []map[int32]int64
 		should.NoError(c.Unmarshal(output, &val))

--- a/test/level_2/list_of_string_test.go
+++ b/test/level_2/list_of_string_test.go
@@ -57,10 +57,15 @@ func Test_unmarshal_list_of_string(t *testing.T) {
 func Test_marshal_general_list_of_string(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.List{
+		lst := general.List{
 			"a", "b", "c",
-		})
+		}
+
+		output, err := c.Marshal(lst)
 		should.NoError(err)
+		output1, err := c.Marshal(&lst)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val []string
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal([]string{
@@ -72,7 +77,12 @@ func Test_marshal_general_list_of_string(t *testing.T) {
 func Test_marshal_list_of_string(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal([]string{"a", "b", "c"})
+		lst := []string{"a", "b", "c"}
+
+		output, err := c.Marshal(lst)
+		should.NoError(err)
+		output1, err := c.Marshal(&lst)
+		should.Equal(output, output1)
 		should.NoError(err)
 		var val []string
 		should.NoError(c.Unmarshal(output, &val))

--- a/test/level_2/list_of_struct_test.go
+++ b/test/level_2/list_of_struct_test.go
@@ -88,34 +88,50 @@ func Test_unmarshal_list_of_struct(t *testing.T) {
 func Test_marshal_general_list_of_struct(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.List{
+		lst := general.List{
 			general.Struct{
 				protocol.FieldId(1): int64(1024),
 			},
 			general.Struct{
 				protocol.FieldId(1): int64(1024),
 			},
-		})
+		}
+
+		output, err := c.Marshal(lst)
 		should.NoError(err)
+		output1, err := c.Marshal(&lst)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.List
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Struct{
 			protocol.FieldId(1): int64(1024),
 		}, val[0])
+		should.Equal(general.Struct{
+			protocol.FieldId(1): int64(1024),
+		}, val[1])
 	}
 }
 
 func Test_marshal_list_of_struct(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal([]list_of_struct_test.TestObject{
+		lst := []list_of_struct_test.TestObject{
 			{1024}, {1024},
-		})
+		}
+
+		output, err := c.Marshal(lst)
+		should.NoError(err)
+		output1, err := c.Marshal(&lst)
+		should.Equal(output, output1)
 		should.NoError(err)
 		var val general.List
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Struct{
 			protocol.FieldId(1): int64(1024),
 		}, val[0])
+		should.Equal(general.Struct{
+			protocol.FieldId(1): int64(1024),
+		}, val[1])
 	}
 }

--- a/test/level_2/map_of_list_test.go
+++ b/test/level_2/map_of_list_test.go
@@ -62,10 +62,15 @@ func Test_unmarshal_map_of_list(t *testing.T) {
 func Test_marshal_general_map_of_list(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.Map{
+		m := general.Map{
 			int64(1): general.List{int64(1)},
-		})
+		}
+
+		output, err := c.Marshal(m)
 		should.NoError(err)
+		output1, err := c.Marshal(&m)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Map
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.List{
@@ -77,9 +82,14 @@ func Test_marshal_general_map_of_list(t *testing.T) {
 func Test_marshal_map_of_list(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal(map[int64][]int64{
+		m := map[int64][]int64{
 			1: {1},
-		})
+		}
+
+		output, err := c.Marshal(m)
+		should.NoError(err)
+		output1, err := c.Marshal(&m)
+		should.Equal(output, output1)
 		should.NoError(err)
 		var val general.Map
 		should.NoError(c.Unmarshal(output, &val))

--- a/test/level_2/map_of_map_test.go
+++ b/test/level_2/map_of_map_test.go
@@ -50,12 +50,17 @@ func Test_unmarshal_general_map_of_map(t *testing.T) {
 func Test_marshal_general_map_of_map(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.Map{
+		m := general.Map{
 			int64(1): general.Map{
 				"k1": int64(1),
 			},
-		})
+		}
+
+		output, err := c.Marshal(m)
 		should.NoError(err)
+		output1, err := c.Marshal(&m)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Map
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Map{
@@ -67,10 +72,15 @@ func Test_marshal_general_map_of_map(t *testing.T) {
 func Test_marshal_map_of_map(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal(map[int64]map[string]int64{
+		m := map[int64]map[string]int64{
 			1: {"k1": 1},
-		})
+		}
+
+		output, err := c.Marshal(m)
 		should.NoError(err)
+		output1, err := c.Marshal(&m)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Map
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Map{

--- a/test/level_2/map_of_string_test.go
+++ b/test/level_2/map_of_string_test.go
@@ -69,10 +69,15 @@ func Test_unmarshal_map_of_string_key(t *testing.T) {
 func Test_marshal_general_map_of_string_key(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.Map{
+		m := general.Map{
 			"1": int64(1),
-		})
+		}
+
+		output, err := c.Marshal(m)
 		should.NoError(err)
+		output1, err := c.Marshal(&m)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Map
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Map{
@@ -84,10 +89,15 @@ func Test_marshal_general_map_of_string_key(t *testing.T) {
 func Test_marshal_map_of_string_key(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal(map[string]int64{
+		m := map[string]int64{
 			"1": 1,
-		})
+		}
+
+		output, err := c.Marshal(m)
 		should.NoError(err)
+		output1, err := c.Marshal(&m)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Map
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Map{

--- a/test/level_2/map_of_struct_test.go
+++ b/test/level_2/map_of_struct_test.go
@@ -79,12 +79,17 @@ func Test_unmarshal_map_of_struct(t *testing.T) {
 func Test_marshal_general_map_of_struct(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.Map{
+		m := general.Map{
 			int64(1): general.Struct {
 				protocol.FieldId(1): int64(1024),
 			},
-		})
+		}
+
+		output, err := c.Marshal(m)
 		should.NoError(err)
+		output1, err := c.Marshal(&m)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Map
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Struct{
@@ -96,10 +101,15 @@ func Test_marshal_general_map_of_struct(t *testing.T) {
 func Test_marshal_map_of_struct(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal(map[int64]map_of_struct_test.TestObject{
+		m := map[int64]map_of_struct_test.TestObject{
 			1: {1024},
-		})
+		}
+
+		output, err := c.Marshal(m)
 		should.NoError(err)
+		output1, err := c.Marshal(&m)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Map
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Struct{

--- a/test/level_2/struct_complex_test.go
+++ b/test/level_2/struct_complex_test.go
@@ -1,0 +1,112 @@
+package test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/thrift-iterator/go/test"
+	"github.com/thrift-iterator/go/test/level_2/struct_complex_test"
+	"testing"
+)
+
+func Test_marshal_struct_complex(t *testing.T) {
+	should := require.New(t)
+	for _, c := range test.MarshalCombinations[:] {
+		var obj struct_complex_test.TestObject
+		obj.Av = false
+		obj.Ap = &obj.Av
+		obj.Bv = 1
+		obj.Bp = &obj.Bv
+		obj.Cv = 2
+		obj.Cp = &obj.Cv
+		obj.Dv = 3
+		obj.Dp = &obj.Dv
+		obj.Ev = 4
+		obj.Ep = &obj.Ev
+		obj.Fv = 5
+		obj.Fp = &obj.Fv
+		obj.Gv = 3.1415926
+		obj.Gp = &obj.Gv
+		obj.Hv = "6"                        // 15
+		obj.Hp = &obj.Hv                    // 16
+		obj.Iv = []byte{7}                  // 17
+		obj.Ip = &obj.Iv                    // 18
+		obj.Jv = []string{"8"}              // 19
+		obj.Jp = &obj.Jv                    // 20
+		obj.Kv = map[string]bool{"9": true} // 21
+		obj.Kp = &obj.Kv
+		obj.Lv = map[int32]struct_complex_test.SubType{10: {A: 10}}
+		obj.Lp = &obj.Lv
+		obj.Mv = map[int32]map[int32]string{
+			101: {102: "103"},
+		}
+		obj.Mp = &obj.Mv
+		obj.Nv = [][]string{
+			{"201", "202"},
+		}
+		obj.Np = &obj.Nv
+		obj.Ov = 11
+		obj.Op = &obj.Ov
+		obj.Pv = struct_complex_test.Enum_B
+		obj.Pp = &obj.Pv
+		obj.Qv = map[int32][]string{
+			12: {"1201", "1201"},
+		}
+		obj.Qp = &obj.Qv
+		obj.Rv = []map[string][]map[string]int32{
+			{"foo": []map[string]int32{
+				{"foo1": 1801},
+				{"foo2": 1802},
+			}},
+			{"bar": []map[string]int32{
+				{"bar1": 1803},
+				{"bar2": 1804},
+			}},
+		}
+		obj.Rp = &obj.Rv
+
+		output, err := c.Marshal(obj)
+		should.NoError(err)
+		output1, err := c.Marshal(&obj)
+		should.NoError(err)
+		should.Equal(output, output1)
+
+		var val *struct_complex_test.TestObject
+		should.NoError(c.Unmarshal(output, &val))
+
+		should.Equal(obj.Av, val.Av)
+		should.Equal(*obj.Ap, *val.Ap)
+		should.Equal(obj.Bv, val.Bv)
+		should.Equal(obj.Bv, *val.Bp)
+		should.Equal(obj.Cv, val.Cv)
+		should.Equal(obj.Cv, *val.Cp)
+		should.Equal(obj.Dv, val.Dv)
+		should.Equal(obj.Dv, *val.Dp)
+		should.Equal(obj.Ev, val.Ev)
+		should.Equal(obj.Ev, *val.Ep)
+		should.Equal(obj.Fv, val.Fv)
+		should.Equal(obj.Fv, *val.Fp)
+		should.Equal(obj.Gv, val.Gv)
+		should.Equal(obj.Gv, *val.Gp)
+		should.Equal(obj.Hv, val.Hv)
+		should.Equal(obj.Hv, *val.Hp)
+		should.Equal(obj.Iv, val.Iv)
+		should.Equal(obj.Iv, *val.Ip)
+		should.Equal(obj.Jv, val.Jv)
+		should.Equal(obj.Jv, *val.Jp)
+		should.Equal(obj.Kv, val.Kv)
+		should.Equal(obj.Kv, *val.Kp)
+		should.Equal(obj.Lv, val.Lv)
+		should.Equal(obj.Lv, *val.Lp)
+		should.Equal(obj.Mv, val.Mv)
+		should.Equal(obj.Mv, *val.Mp)
+		should.Equal(obj.Nv, val.Nv)
+		should.Equal(obj.Nv, *val.Np)
+		should.Equal(obj.Ov, val.Ov)
+		should.Equal(obj.Ov, *val.Op)
+		should.Equal(obj.Pv, val.Pv)
+		should.Equal(obj.Pv, *val.Pp)
+		should.Equal(obj.Qv, val.Qv)
+		should.Equal(obj.Qv, *val.Qp)
+		should.Equal(obj.Rv, val.Rv)
+		should.Equal(obj.Rv, *val.Rp)
+	}
+}

--- a/test/level_2/struct_complex_test/TestObject.go
+++ b/test/level_2/struct_complex_test/TestObject.go
@@ -1,0 +1,54 @@
+package struct_complex_test
+
+type SubType struct {
+	A int32 `thrift:"a,1"`
+}
+
+type Enum int32
+
+const (
+	Enum_A Enum = 1
+
+	Enum_B Enum = 2
+)
+
+type Int int32
+
+type TestObject struct {
+	Av bool                             `thrift:"av,1"`
+	Ap *bool                            `thrift:"ap,2,optional"`
+	Bv int8                             `thrift:"bv,3"`
+	Bp *int8                            `thrift:"bp,4,optional"`
+	Cv int8                             `thrift:"cv,5"`
+	Cp *int8                            `thrift:"cp,6,optional"`
+	Dv int16                            `thrift:"dv,7"`
+	Dp *int16                           `thrift:"dp,8,optional"`
+	Ev int32                            `thrift:"ev,9"`
+	Ep *int32                           `thrift:"ep,10,optional"`
+	Fv int64                            `thrift:"fv,11"`
+	Fp *int64                           `thrift:"fp,12,optional"`
+	Gv float64                          `thrift:"gv,13"`
+	Gp *float64                         `thrift:"gp,14,optional"`
+	Hv string                           `thrift:"hv,15"`
+	Hp *string                          `thrift:"hp,16,optional"`
+	Iv []byte                           `thrift:"iv,17,optional"`
+	Ip *[]byte                          `thrift:"ip,18,optional"`
+	Jv []string                         `thrift:"jv,19,optional"`
+	Jp *[]string                        `thrift:"jp,20,optional"`
+	Kv map[string]bool                  `thrift:"kv,21,optional"`
+	Kp *map[string]bool                 `thrift:"kp,22,optional"`
+	Lv map[int32]SubType                `thrift:"lv,23,optional"`
+	Lp *map[int32]SubType               `thrift:"lp,24,optional"`
+	Mv map[int32]map[int32]string       `thrift:"mv,25,optional"`
+	Mp *map[int32]map[int32]string      `thrift:"mp,26,optional"`
+	Nv [][]string                       `thrift:"nv,27,optional"`
+	Np *[][]string                      `thrift:"np,28,optional"`
+	Ov Int                              `thrift:"ov,29"`
+	Op *Int                             `thrift:"op,30,optional"`
+	Pv Enum                             `thrift:"pv,31"`
+	Pp *Enum                            `thrift:"pp,32,optional"`
+	Qv map[int32][]string               `thrift:"qv,33,optional"`
+	Qp *map[int32][]string              `thrift:"qp,34,optional"`
+	Rv []map[string][]map[string]int32  `thrift:"rv,35,optional"`
+	Rp *[]map[string][]map[string]int32 `thrift:"rp,36,optional"`
+}

--- a/test/level_2/struct_of_list_test.go
+++ b/test/level_2/struct_of_list_test.go
@@ -68,12 +68,17 @@ func Test_unmarshal_struct_of_list(t *testing.T) {
 func Test_marshal_general_struct_of_list(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.Struct {
+		obj := general.Struct {
 			protocol.FieldId(1): general.List {
 				int64(1),
 			},
-		})
+		}
+
+		output, err := c.Marshal(obj)
 		should.NoError(err)
+		output1, err := c.Marshal(&obj)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Struct
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.List{int64(1)}, val[protocol.FieldId(1)])
@@ -83,10 +88,15 @@ func Test_marshal_general_struct_of_list(t *testing.T) {
 func Test_marshal_struct_of_list(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal(struct_of_list_test.TestObject{
+		obj := struct_of_list_test.TestObject{
 			[]int64{1},
-		})
+		}
+
+		output, err := c.Marshal(obj)
 		should.NoError(err)
+		output1, err := c.Marshal(&obj)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Struct
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.List{int64(1)}, val[protocol.FieldId(1)])

--- a/test/level_2/struct_of_map_test.go
+++ b/test/level_2/struct_of_map_test.go
@@ -73,12 +73,17 @@ func Test_unmarshal_struct_of_map(t *testing.T) {
 func Test_marshal_general_struct_of_map(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.Struct{
+		m := general.Struct{
 			protocol.FieldId(1): general.Map{
 				int32(2): int64(2),
 			},
-		})
+		}
+
+		output, err := c.Marshal(m)
 		should.NoError(err)
+		output1, err := c.Marshal(&m)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Struct
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Map{
@@ -90,10 +95,15 @@ func Test_marshal_general_struct_of_map(t *testing.T) {
 func Test_marshal_struct_of_map(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal(struct_of_map_test.TestObject{
+		m := struct_of_map_test.TestObject{
 			map[int32]int64{2: 2},
-		})
+		}
+
+		output, err := c.Marshal(m)
 		should.NoError(err)
+		output1, err := c.Marshal(&m)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Struct
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Map{

--- a/test/level_2/struct_of_pointer_test.go
+++ b/test/level_2/struct_of_pointer_test.go
@@ -48,10 +48,15 @@ func Test_marshal_struct_of_1_ptr(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
 		one := 1
-		output, err := c.Marshal(struct_of_pointer_test.StructOf1Ptr{
+		obj := struct_of_pointer_test.StructOf1Ptr{
 			&one,
-		})
+		}
+
+		output, err := c.Marshal(obj)
 		should.NoError(err)
+		output1, err := c.Marshal(&obj)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val *struct_of_pointer_test.StructOf1Ptr
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(1, *val.Field1)
@@ -63,10 +68,15 @@ func Test_marshal_struct_of_2_ptr(t *testing.T) {
 	for _, c := range test.MarshalCombinations {
 		one := 1
 		two := 2
-		output, err := c.Marshal(struct_of_pointer_test.StructOf2Ptr{
+		obj := struct_of_pointer_test.StructOf2Ptr{
 			&one, &two,
-		})
+		}
+
+		output, err := c.Marshal(obj)
 		should.NoError(err)
+		output1, err := c.Marshal(&obj)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val *struct_of_pointer_test.StructOf2Ptr
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(1, *val.Field1)

--- a/test/level_2/struct_of_string_test.go
+++ b/test/level_2/struct_of_string_test.go
@@ -62,10 +62,15 @@ func Test_unmarshal_struct_of_string(t *testing.T) {
 func Test_marshal_general_struct_of_string(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.Struct{
+		obj := general.Struct{
 			protocol.FieldId(1): "abc",
-		})
+		}
+
+		output, err := c.Marshal(obj)
 		should.NoError(err)
+		output1, err := c.Marshal(&obj)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Struct
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal("abc", val[protocol.FieldId(1)])
@@ -75,10 +80,15 @@ func Test_marshal_general_struct_of_string(t *testing.T) {
 func Test_marshal_struct_of_string(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal(struct_of_string_test.TestObject{
+		obj := struct_of_string_test.TestObject{
 			"abc",
-		})
+		}
+
+		output, err := c.Marshal(obj)
 		should.NoError(err)
+		output1, err := c.Marshal(&obj)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Struct
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal("abc", val[protocol.FieldId(1)])

--- a/test/level_2/struct_of_struct_test.go
+++ b/test/level_2/struct_of_struct_test.go
@@ -85,12 +85,17 @@ func Test_unmarshal_struct_of_struct(t *testing.T) {
 func Test_marshal_general_struct_of_struct(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.Combinations {
-		output, err := c.Marshal(general.Struct{
+		obj := general.Struct{
 			protocol.FieldId(1): general.Struct{
 				protocol.FieldId(1): "abc",
 			},
-		})
+		}
+
+		output, err := c.Marshal(obj)
 		should.NoError(err)
+		output1, err := c.Marshal(&obj)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Struct
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Struct{
@@ -102,10 +107,15 @@ func Test_marshal_general_struct_of_struct(t *testing.T) {
 func Test_marshal_struct_of_struct(t *testing.T) {
 	should := require.New(t)
 	for _, c := range test.MarshalCombinations {
-		output, err := c.Marshal(struct_of_struct_test.TestObject{
+		obj := struct_of_struct_test.TestObject{
 			struct_of_struct_test.EmbeddedObject{"abc"},
-		})
+		}
+
+		output, err := c.Marshal(obj)
 		should.NoError(err)
+		output1, err := c.Marshal(&obj)
+		should.NoError(err)
+		should.Equal(output, output1)
 		var val general.Struct
 		should.NoError(c.Unmarshal(output, &val))
 		should.Equal(general.Struct{


### PR DESCRIPTION
Fix:
1. panic when encoding struct with nil pointer field
2. panic when encoding struct which has only one map field
3. wrong bool value marshaling caused of un-reset of pendingBoolField in compact protocol
4. return value of ReadBinary in sbinary should be copied

Change:
1. allow encoding and decoding struct field with FieldId 0, to be compatible with apache thrift rpc response