### PR TITLE
minor performance improvement

### DIFF
--- a/protocol/binary/iterator.go
+++ b/protocol/binary/iterator.go
@@ -21,7 +21,7 @@ func NewIterator(provider spi.ValDecoderProvider, reader io.Reader, buf []byte) 
 	return &Iterator{
 		ValDecoderProvider: provider,
 		reader:             reader,
-		tmp:                make([]byte, 10),
+		tmp:                make([]byte, 8),
 		preread:            buf,
 	}
 }
@@ -80,34 +80,7 @@ func (iter *Iterator) readLarge(nBytes int) []byte {
 	if len(iter.tmp) < nBytes {
 		iter.tmp = make([]byte, nBytes)
 	}
-	tmp := iter.tmp[:nBytes]
-	wantBytes := nBytes
-	if len(iter.preread) > 0 {
-		if len(iter.preread) > nBytes {
-			copy(tmp, iter.preread[:nBytes])
-			iter.preread = iter.preread[nBytes:]
-			wantBytes = 0
-		} else {
-			prelength := len(iter.preread)
-			copy(tmp[:prelength], iter.preread)
-			wantBytes -= prelength
-			iter.preread = nil
-		}
-	}
-	if wantBytes > 0 {
-		_, err := io.ReadFull(iter.reader, tmp[nBytes-wantBytes:nBytes])
-		if err != nil {
-			for i := 0; i < len(tmp); i++ {
-				tmp[i] = 0
-			}
-			iter.ReportError("read", err.Error())
-			return tmp
-		}
-	}
-	if iter.skipped != nil {
-		iter.skipped = append(iter.skipped, tmp...)
-	}
-	return tmp
+	return iter.readSmall(nBytes)
 }
 
 func (iter *Iterator) Spawn() spi.Iterator {

--- a/protocol/binary/skip.go
+++ b/protocol/binary/skip.go
@@ -4,7 +4,7 @@ import "github.com/thrift-iterator/go/protocol"
 
 func (iter *Iterator) skip(skipper func(), space []byte) []byte {
 	var tmp []byte
-	iter.skipped = make([]byte, 0, 10)
+	iter.skipped = make([]byte, 0, 8)
 	skipper()
 	tmp, iter.skipped = iter.skipped, nil
 	if iter.Error() != nil {

--- a/protocol/compact/skip.go
+++ b/protocol/compact/skip.go
@@ -4,7 +4,7 @@ import "github.com/thrift-iterator/go/protocol"
 
 func (iter *Iterator) skip(skipper func(), space []byte) []byte {
 	var tmp []byte
-	iter.skipped = make([]byte, 0, 10)
+	iter.skipped = make([]byte, 0, 8)
 	skipper()
 	tmp, iter.skipped = iter.skipped, nil
 	if iter.Error() != nil {

--- a/spi/discard.go
+++ b/spi/discard.go
@@ -1,12 +1,9 @@
 package spi
 
-import "github.com/thrift-iterator/go/protocol"
-
 func DiscardList(iter Iterator) {
 	elemType, size := iter.ReadListHeader()
-	discardElem := howToDiscard(iter, elemType)
 	for i := 0; i < size; i++ {
-		discardElem()
+		iter.Discard(elemType)
 	}
 }
 
@@ -23,26 +20,8 @@ func DiscardStruct(iter Iterator) {
 
 func DiscardMap(iter Iterator) {
 	keyType, elemType, size := iter.ReadMapHeader()
-	discardKey := howToDiscard(iter, keyType)
-	discardElem := howToDiscard(iter, elemType)
 	for i := 0; i < size; i++ {
-		discardKey()
-		discardElem()
+		iter.Discard(keyType)
+		iter.Discard(elemType)
 	}
-}
-
-func howToDiscard(iter Iterator, elemType protocol.TType) func() {
-	switch elemType {
-	case protocol.TypeBool, protocol.TypeI08,
-		protocol.TypeI16, protocol.TypeI32, protocol.TypeI64,
-		protocol.TypeDouble, protocol.TypeString:
-		return func() { iter.Discard(elemType) }
-	case protocol.TypeList:
-		return func() { DiscardList(iter) }
-	case protocol.TypeStruct:
-		return func() { DiscardStruct(iter) }
-	case protocol.TypeMap:
-		return func() { DiscardMap(iter) }
-	}
-	panic("unsupported type")
 }


### PR DESCRIPTION
1. remove unnecessary closures for sake of performance.
2. change iterator default tmp buffer size to more reasonable 8.
3. avoid totally copied code in readLarge function.